### PR TITLE
fixes for rocky9 / kernel 5.14

### DIFF
--- a/driver/mrfcommon.c
+++ b/driver/mrfcommon.c
@@ -469,8 +469,13 @@ struct page *ev_vma_nopage(struct vm_area_struct *vma, unsigned long address, in
 {
     return NOPAGE_SIGBUS;
 }
-#else
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0)
 int ev_vma_fault(struct vm_area_struct *vma, struct vm_fault *vmf)
+{
+    return VM_FAULT_SIGBUS;
+}
+#else
+vm_fault_t ev_vma_fault(struct vm_fault *vmf)
 {
     return VM_FAULT_SIGBUS;
 }
@@ -623,9 +628,17 @@ int ev_ioctl(struct inode *inode, struct file *filp,
     return -ENOTTY;
   /* Check access */
   if (_IOC_DIR(cmd) & _IOC_READ)
+#ifdef VERIFY_WRITE
     ret = !access_ok(VERIFY_WRITE, (void __user *)arg, _IOC_SIZE(cmd));
+#else
+    ret = !access_ok((void __user *)arg, _IOC_SIZE(cmd));
+#endif
   else if (_IOC_DIR(cmd) & _IOC_WRITE)
+#ifdef VERIFY_READ
     ret = !access_ok(VERIFY_READ, (void __user *)arg, _IOC_SIZE(cmd));
+#else
+    ret = !access_ok((void __user *)arg, _IOC_SIZE(cmd));
+#endif
   if (ret)
     return -EFAULT;
 

--- a/driver/mrfevr.c
+++ b/driver/mrfevr.c
@@ -34,6 +34,14 @@ MODULE_LICENSE("GPL");
 
 #define DEVICE_NAME           "evr_device"
 
+/* ioremap_nocache was removed in 5.6+. though ioremap and ioremap_nocache
+   have been the same since 2.6.25. */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 25)
+#define IOREMAP_NOCACHE(address, size) ioremap(address, size)
+#else
+#define IOREMAP_NOCACHE(address, size) ioremap_nocache(address, size)
+#endif
+
 extern struct mrf_dev mrf_devices[MAX_MRF_DEVICES];
 static struct timer_list mrf_timer;
 
@@ -198,7 +206,7 @@ static int pci_evr_probe(struct pci_dev *pcidev, const struct pci_device_id *dev
     if (request_mem_region(ev_device->mrEv, ev_device->lenEv,
 			   DEVICE_NAME) != NULL)
       {
-        ev_device->pEv = ioremap_nocache(evr_base_start,
+        ev_device->pEv = IOREMAP_NOCACHE(evr_base_start,
 					 ev_device->lenEv);
       }
   } else {
@@ -211,7 +219,7 @@ static int pci_evr_probe(struct pci_dev *pcidev, const struct pci_device_id *dev
     if (request_mem_region(ev_device->mrLC, ev_device->lenLC,
 		 	   DEVICE_NAME) != NULL)
       {
-        ev_device->pLC = ioremap_nocache(local_conf_start,
+        ev_device->pLC = IOREMAP_NOCACHE(local_conf_start,
 				         ev_device->lenLC);
       }
 
@@ -224,7 +232,7 @@ static int pci_evr_probe(struct pci_dev *pcidev, const struct pci_device_id *dev
     if (request_mem_region(ev_device->mrEv, ev_device->lenEv,
 			   DEVICE_NAME) != NULL)
       {
-        ev_device->pEv = ioremap_nocache(evr_base_start,
+        ev_device->pEv = IOREMAP_NOCACHE(evr_base_start,
 					 ev_device->lenEv);
       }
 
@@ -327,7 +335,11 @@ int ev_assign_irq(struct mrf_dev *ev_device)
   return result;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,14,0)
 void mrf_callback(unsigned long data)
+#else
+void mrf_callback(struct timer_list *data)
+#endif
 {
     int i;
 
@@ -345,7 +357,11 @@ static int __init pci_evr_init(void)
   /* Allocate and clear memory for all devices. */
   memset(mrf_devices, 0, sizeof(struct mrf_dev)*MAX_MRF_DEVICES);
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,14,0)
   setup_timer(&mrf_timer, mrf_callback, 0);
+#else
+  timer_setup(&mrf_timer, mrf_callback, 0);
+#endif
   mod_timer(&mrf_timer, jiffies + msecs_to_jiffies(1000));
 
   printk(KERN_ALERT "Event Receiver PCI driver 2.1 (ev2_driver 1.0.4) init.\n");

--- a/driver/pci_mrfev.h
+++ b/driver/pci_mrfev.h
@@ -143,6 +143,9 @@ ssize_t ev_read(struct file *filp, char __user *buf, size_t count,
 		loff_t *f_pos);
 ssize_t ev_write(struct file *filp, const char __user *buf, size_t count,
 		 loff_t *f_pos);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0) /* The HAVE_UNLOCKED_IOCTL flag was removed */
+#define HAVE_UNLOCKED_IOCTL 1
+#endif
 #ifdef HAVE_UNLOCKED_IOCTL
 long ev_unlocked_ioctl(struct file *filp,
 	     unsigned int cmd, unsigned long arg);


### PR DESCRIPTION
Fixes to driver so that it compiles for rocky9. Done in a way to preserve support for older kernels.

The LCLS1 daq is still using this driver and IT has started updating the machines we run it on to rocky9. I tested the changes with using the lcls1 daq and the evr behaves as expected. I haven't seen any issues so far.